### PR TITLE
Fix crash on shutdown if init failed

### DIFF
--- a/src/ts3interface.rs
+++ b/src/ts3interface.rs
@@ -73,8 +73,7 @@ pub unsafe extern "C" fn ts3plugin_setFunctionPointers(funs: Ts3Functions) {
 pub unsafe extern "C" fn ts3plugin_shutdown() {
     let data = DATA.lock().unwrap();
     let mut data = data.borrow_mut();
-    {
-        let mut data = data.as_mut().unwrap();
+    if let Some(mut data) = data.as_mut() {
         let mut api = &mut data.0;
         let mut plugin = &mut data.1;
         plugin.shutdown(api);


### PR DESCRIPTION
If the init failed, data remains `None`. The shutdown unconditionally
unwraps data which leads to a panic in the plugin and a crash of
Teamspeak. This changes verifies that data is not `None` before using it.