### PR TITLE
Fix crashing on switch channel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,11 +518,13 @@ impl<'a> Server<'a> {
 	}
 
 	pub fn get_server_group(&self, _server_group_id: ServerGroupId) -> Option<ServerGroup> {
-		todo!()
+		//todo!()
+		Some(ServerGroup {})
 	}
 
 	pub fn get_channel_group(&self, _channel_group_id: ChannelGroupId) -> Option<ChannelGroup> {
-		todo!()
+		//todo!()
+		Some(ChannelGroup {})
 	}
 
 	/// Send a message to the server chat.


### PR DESCRIPTION
Due to how the todo macro works it will panic every time it tries to get groups, such as when switching channels. This fixes the crashes. See https://doc.rust-lang.org/std/macro.todo.html

Example stacktrace of a crash:
```
# RetAddr               : Args to Child                                                           : Call Site
00 00007ffd`854c5277     : 000002bd`f588c700 000000d2`21b0a958 000000d2`21b0a8f0 00007ffd`32827406 : KERNELBASE!RaiseException+0x8a
01 00007ffd`3282af1d     : 00000000`00000013 00007ffd`3282a7b7 00000000`00000001 000000d2`21b0aad8 : VCRUNTIME140!_CxxThrowException+0x97 [D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\throw.cpp @ 80] 
02 00007ffd`3282ae75     : 000000d2`21b0a9a0 00007ffd`32827198 00000000`000000ff 00000000`00000000 : ts3_discord!panic_unwind::imp::throw_exception+0x7d [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\panic_unwind\src\seh.rs @ 366] 
03 (Inline Function)     : --------`-------- --------`-------- --------`-------- --------`-------- : ts3_discord!panic_unwind::imp::panic+0x8 [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\panic_unwind\src\seh.rs @ 302] 
04 00007ffd`328212d5     : 00007ffd`3283d830 00000000`00000013 00007ffd`3283db08 00000000`00000000 : ts3_discord!panic_unwind::__rust_start_panic+0x15 [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\panic_unwind\src\lib.rs @ 110] 
05 00007ffd`32827ca3     : 3e7f5240`7779b045 00000000`00000002 00000000`0000063d 00000000`00000002 : ts3_discord!std::panicking::rust_panic+0x15 [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\std\src\panicking.rs @ 895] 
06 00007ffd`32827a82     : 000000d2`21b0aa60 000002bd`f7390d10 000002bd`f7390d10 00007ffd`32808918 : ts3_discord!std::panicking::panic_with_hook+0x11f [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\std\src\panicking.rs @ 825] 
07 00007ffd`3282606f     : 00007ffd`32856008 000000d2`21b0ac48 000002bd`f7390698 00007ffd`32807e17 : ts3_discord!std::panicking::panic_handler::closure$0+0x72 [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\std\src\panicking.rs @ 708] 
08 00007ffd`328215ee     : 000000d2`21b0ab8e 000002bd`f57fdaf0 000002bd`f57fd778 000002bd`f57fd778 : ts3_discord!std::sys::backtrace::__rust_end_short_backtrace<std::panicking::panic_handler::closure_env$0,never$>+0xf [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\std\src\sys\backtrace.rs @ 174] 
09 00007ffd`32838461     : 000002bd`f57fd778 00007ffd`3280aec1 000002bd`f57fd778 00007ffd`328060be : ts3_discord!std::panicking::panic_handler+0x1e [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\std\src\panicking.rs @ 698] 
0a 00007ffd`3283843d     : 000000d2`21b0aca8 000002bd`f57fd778 000000d2`21b0ac56 000000d2`21b0ac48 : ts3_discord!core::panicking::panic_fmt+0x21 [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\core\src\panicking.rs @ 75] 
0b 00007ffd`32807eb6     : 000000d2`21b0aca6 00007ffd`328080b3 00007ffd`00000000 ffffffff`fffffffe : ts3_discord!core::panicking::panic+0x3d [/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library\core\src\panicking.rs @ 145] 
0c 00007ffd`32808253     : 000000d2`21b0aeb0 000000d2`21b0ae98 063d7ffd`32856008 00000000`00000000 : ts3_discord!ts3plugin::Server::get_channel_group+0x26 [C:\Users\liljekvist\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\ts3plugin-0.3.0\src\lib.rs @ 525] 
0d 00007ffd`327d7daa     : 00000000`00000000 000002bd`e9440cf0 00000155`00000028 00000000`00000000 : ts3_discord!ts3plugin::Server::get_channel_group_unwrap+0x13 [C:\Users\liljekvist\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\ts3plugin-0.3.0\src\lib.rs @ 457] 
0e 00007ff7`236f2111     : 000002bd`f77dd070 000000d2`00000000 00000000`0000e91c 000002bd`f77dd060 : ts3_discord!ts3plugin::ts3interface::ts3plugin_onClientChannelGroupChangedEvent+0x30a [C:\Users\liljekvist\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\ts3plugin-0.3.0\src\ts3interface.rs @ 1055] 
0f 00007ff7`2351edf2     : 000002bd`f588c7e0 00000000`00002af0 00000000`0000e91c 000002bd`f588c7e0 : ts3client_win64+0x2a2111
10 00007ffd`2e8095c1     : 000002bd`f588c7e0 000002bd`f588c7e0 00000000`00000000 000002bd`f6b39270 : ts3client_win64+0xcedf2
11 00007ffd`2da38675     : 00000000`00000000 00000000`00000000 000002bd`eb442d30 000002bd`f57c41b0 : Qt5Core!QObject::event+0x171
12 00007ffd`2dad8ee0     : 000002bd`e95c3b90 000002bd`f588c7e0 000002bd`e957cda0 000002bd`f6b39370 : Qt5Widgets!QWidget::event+0xdf5
13 00007ffd`2da14990     : 000002bd`e95eb0a0 000002bd`f6b39370 000002bd`f6b39370 000002bd`f588c7e0 : Qt5Widgets!QFrame::event+0x30
14 00007ffd`2da13a13     : 000002bd`e95c3b90 000000d2`21b0b680 00007ffd`2da00000 000002bd`f57c41b0 : Qt5Widgets!QApplicationPrivate::notify_helper+0x110
15 00007ffd`2e7e2aca     : 000002bd`f6b39370 000000d2`21b0bb38 000002bd`e9500000 000002bd`e95c3b90 : Qt5Widgets!QApplication::notify+0x18b3
16 00007ffd`2e7e4845     : 00000000`00000000 00007ffd`b5ffe0ef 000002bd`f6b39370 00000000`00000000 : Qt5Core!QCoreApplication::notifyInternal2+0xba
17 00007ffd`2fdf2dff     : 000002bd`f6b39370 00007ff7`00000000 000002bd`eb44d970 000002bd`f6fccb30 : Qt5Core!QCoreApplicationPrivate::sendPostedEvents+0x215
18 00007ffd`2e82ba5a     : 000002bd`eb44d970 000000d2`00000004 00000000`00000000 000002bd`f6fccb30 : qwindows!qt_plugin_query_metadata+0x1fbf
19 00007ffd`2fdf2dd9     : 000002bd`eb44d970 00000000`00000000 000002bd`f6fccb30 00000000`00000000 : Qt5Core!QEventDispatcherWin32::processEvents+0x6a
1a 00007ffd`2e7def2c     : 00000000`00000000 00007ffd`00000014 00000000`00000000 00000000`00000000 : qwindows!qt_plugin_query_metadata+0x1f99
1b 00007ffd`2e7e1a94     : 000002bd`e9510888 00000000`00000000 000000d2`21b0f970 00007ffd`2e901c90 : Qt5Core!QEventLoop::exec+0x1bc
1c 00007ff7`239cd6a7     : 000000d2`21b0f3c0 00000000`00000000 00007ff7`2440cae0 000002bd`ebba2540 : Qt5Core!QCoreApplication::exec+0x154
1d 00007ff7`239e277f     : 00000000`00000000 00000000`00000001 00000000`00000001 000002bd`e9515a80 : ts3client_win64+0x57d6a7
1e 00007ff7`241bfe5a     : 00000000`00000001 00000000`00000000 00000000`00000000 00000000`00000000 : ts3client_win64+0x59277f
1f 00007ffd`b6ace8d7     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : ts3client_win64!ts3soundbackend_waitForClosedDevices+0x494a6a
20 00007ffd`b7dcc53c     : 00000000`00000000 00000000`00000000 000004f0`fffffb30 000004d0`fffffb30 : kernel32!BaseThreadInitThunk+0x17
21 00000000`00000000     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : ntdll!RtlUserThreadStart+0x2c
```